### PR TITLE
Log Java stack for humongous allocations

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -95,6 +95,7 @@
 #include "gc/shared/weakProcessor.inline.hpp"
 #include "gc/shared/workerPolicy.hpp"
 #include "logging/log.hpp"
+#include "logging/logStream.hpp"
 #include "memory/allocation.hpp"
 #include "memory/heapInspection.hpp"
 #include "memory/iterator.hpp"
@@ -110,6 +111,7 @@
 #include "runtime/handles.inline.hpp"
 #include "runtime/init.hpp"
 #include "runtime/java.hpp"
+#include "runtime/javaThread.hpp"
 #include "runtime/orderAccess.hpp"
 #include "runtime/threadSMR.hpp"
 #include "runtime/vmThread.hpp"
@@ -120,6 +122,28 @@
 #include "utilities/stack.inline.hpp"
 
 size_t G1CollectedHeap::_humongous_object_threshold_in_words = 0;
+
+static void log_humongous_allocation(HeapWord* result, size_t word_size) {
+  LogTarget(Debug, gc, humongous) lt;
+  if (!lt.is_enabled()) {
+    return;
+  }
+
+  Thread* current = Thread::current();
+  const char* thread_name = current->name();
+
+  LogStream ls(lt);
+  ls.print_cr("Humongous allocation succeeded: object " PTR_FORMAT
+              ", size %zu words (%zu bytes), thread \"%s\"",
+              p2i(result), word_size, word_size * HeapWordSize,
+              thread_name != nullptr ? thread_name : "<unknown>");
+  if (current->is_Java_thread()) {
+    ls.print_cr("Java stack for humongous allocation:");
+    JavaThread::cast(current)->print_stack_on(&ls);
+  } else {
+    ls.print_cr("No Java stack: current thread is not a JavaThread");
+  }
+}
 
 // INVARIANTS/NOTES
 //
@@ -666,8 +690,7 @@ HeapWord* G1CollectedHeap::attempt_allocation_humongous(size_t word_size) {
   // Case b) is the only case when we'll return null.
   HeapWord* result = nullptr;
   for (uint try_count = 1; /* we'll return */; try_count++) {
-    uint gc_count_before;
-
+    uint gc_count_before = 0;
 
     {
       MutexLocker x(Heap_lock);
@@ -680,11 +703,15 @@ HeapWord* G1CollectedHeap::attempt_allocation_humongous(size_t word_size) {
       if (result != nullptr) {
         policy()->old_gen_alloc_tracker()->
           add_allocated_humongous_bytes_since_last_gc(size_in_regions * G1HeapRegion::GrainBytes);
-        return result;
+      } else {
+        // Read the GC count while still holding the Heap_lock.
+        gc_count_before = total_collections();
       }
+    }
 
-      // Read the GC count while still holding the Heap_lock.
-      gc_count_before = total_collections();
+    if (result != nullptr) {
+      log_humongous_allocation(result, word_size);
+      return result;
     }
 
     bool succeeded;
@@ -696,6 +723,7 @@ HeapWord* G1CollectedHeap::attempt_allocation_humongous(size_t word_size) {
         size_t size_in_regions = humongous_obj_size_in_regions(word_size);
         policy()->old_gen_alloc_tracker()->
           record_collection_pause_humongous_allocation(size_in_regions * G1HeapRegion::GrainBytes);
+        log_humongous_allocation(result, word_size);
       }
       return result;
     }

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "classfile/classLoaderDataGraph.hpp"
+#include "classfile/javaClasses.hpp"
 #include "classfile/metadataOnStackMark.hpp"
 #include "classfile/systemDictionary.hpp"
 #include "code/codeCache.hpp"
@@ -95,7 +96,6 @@
 #include "gc/shared/weakProcessor.inline.hpp"
 #include "gc/shared/workerPolicy.hpp"
 #include "logging/log.hpp"
-#include "logging/logStream.hpp"
 #include "memory/allocation.hpp"
 #include "memory/heapInspection.hpp"
 #include "memory/iterator.hpp"
@@ -119,6 +119,7 @@
 #include "utilities/autoRestore.hpp"
 #include "utilities/bitMap.inline.hpp"
 #include "utilities/globalDefinitions.hpp"
+#include "utilities/ostream.hpp"
 #include "utilities/stack.inline.hpp"
 
 size_t G1CollectedHeap::_humongous_object_threshold_in_words = 0;
@@ -130,19 +131,35 @@ static void log_humongous_allocation(HeapWord* result, size_t word_size) {
   }
 
   Thread* current = Thread::current();
-  const char* thread_name = current->name();
-
-  LogStream ls(lt);
-  ls.print_cr("Humongous allocation succeeded: object " PTR_FORMAT
-              ", size %zu words (%zu bytes), thread \"%s\"",
-              p2i(result), word_size, word_size * HeapWordSize,
-              thread_name != nullptr ? thread_name : "<unknown>");
+  stringStream ss;
   if (current->is_Java_thread()) {
-    ls.print_cr("Java stack for humongous allocation:");
-    JavaThread::cast(current)->print_stack_on(&ls);
+    ResourceMark rm(current);
+    JavaThread* java_thread = JavaThread::cast(current);
+    const char* thread_name = current->name();
+    oop java_thread_oop = java_thread->vthread_or_thread();
+    if (java_thread_oop != nullptr) {
+      oop name = java_lang_Thread::name(java_thread_oop);
+      if (name != nullptr) {
+        thread_name = java_lang_String::as_utf8_string(name);
+      }
+    }
+
+    ss.print_cr("Humongous allocation succeeded: object " PTR_FORMAT
+                ", size %zu words (%zu bytes), thread \"%s\"",
+                p2i(result), word_size, word_size * HeapWordSize,
+                thread_name != nullptr ? thread_name : "<unknown>");
+    ss.print_cr("Java stack for humongous allocation:");
+    java_thread->print_active_stack_on(&ss);
   } else {
-    ls.print_cr("No Java stack: current thread is not a JavaThread");
+    const char* thread_name = current->name();
+    ss.print_cr("Humongous allocation succeeded: object " PTR_FORMAT
+                ", size %zu words (%zu bytes), thread \"%s\"",
+                p2i(result), word_size, word_size * HeapWordSize,
+                thread_name != nullptr ? thread_name : "<unknown>");
+    ss.print_cr("No Java stack: current thread is not a JavaThread");
   }
+
+  log_debug(gc, humongous)("%s", ss.as_string());
 }
 
 // INVARIANTS/NOTES

--- a/test/hotspot/jtreg/gc/g1/TestHumongousAllocationStackTrace.java
+++ b/test/hotspot/jtreg/gc/g1/TestHumongousAllocationStackTrace.java
@@ -36,36 +36,123 @@ package gc.g1;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
+import java.util.concurrent.CountDownLatch;
+
 public class TestHumongousAllocationStackTrace {
-    private static final String THREAD_NAME = "HumongousAllocatorThread";
+    private static final String PLATFORM_THREAD_NAME = "HumongousPlatformAllocator";
+    private static final String VIRTUAL_THREAD_NAME = "HumongousVirtualAllocator";
+    private static final String CONCURRENT_THREAD_PREFIX = "HumongousConcurrentAllocator-";
+    private static final int CONCURRENT_THREAD_COUNT = 4;
 
     public static void main(String[] args) throws Exception {
         OutputAnalyzer output = ProcessTools.executeLimitedTestJava(
                 "-XX:+UseG1GC",
-                "-Xms32m",
-                "-Xmx32m",
+                "-Xms128m",
+                "-Xmx128m",
                 "-XX:G1HeapRegionSize=1m",
                 "-Xlog:gc+humongous=debug",
                 HumongousAllocator.class.getName());
 
         output.shouldHaveExitValue(0);
+        output.outputTo(System.out);
+
+        assertAllocationLogged(output, PLATFORM_THREAD_NAME,
+                HumongousAllocator.PlatformHumongousAllocator.class.getName());
+        assertAllocationLogged(output, VIRTUAL_THREAD_NAME,
+                HumongousAllocator.VirtualHumongousAllocator.class.getName());
+        for (int i = 0; i < CONCURRENT_THREAD_COUNT; i++) {
+            assertAllocationLogged(output, CONCURRENT_THREAD_PREFIX + i,
+                    HumongousAllocator.ConcurrentHumongousAllocator.class.getName());
+        }
+    }
+
+    private static void assertAllocationLogged(OutputAnalyzer output, String threadName,
+                                               String allocatorClass) {
         output.shouldContain("Humongous allocation succeeded");
-        output.shouldContain("thread \"" + THREAD_NAME + "\"");
+        output.shouldContain("thread \"" + threadName + "\"");
         output.shouldContain("Java stack for humongous allocation");
-        output.shouldContain("gc.g1.TestHumongousAllocationStackTrace$HumongousAllocator.allocateHumongous");
+        output.shouldContain(allocatorClass + ".allocateHumongous");
+
+        String log = output.getOutput();
+        int allocation = log.indexOf("thread \"" + threadName + "\"");
+        int stack = log.indexOf(allocatorClass + ".allocateHumongous", allocation);
+        int nextAllocation = log.indexOf("Humongous allocation succeeded", allocation + 1);
+        if (stack == -1 || (nextAllocation != -1 && stack > nextAllocation)) {
+            throw new RuntimeException("Stack trace for " + threadName
+                    + " was interleaved with another humongous allocation log");
+        }
     }
 
     public static class HumongousAllocator {
-        private static volatile Object sink;
+        private static final Object[] SINKS = new Object[2 + CONCURRENT_THREAD_COUNT];
 
         public static void main(String[] args) throws Exception {
-            Thread thread = new Thread(HumongousAllocator::allocateHumongous, THREAD_NAME);
+            runPlatformAllocation();
+            runVirtualAllocation();
+            runConcurrentAllocations();
+        }
+
+        private static void runPlatformAllocation() throws InterruptedException {
+            Thread thread = new Thread(PlatformHumongousAllocator::allocateHumongous,
+                    PLATFORM_THREAD_NAME);
             thread.start();
             thread.join();
         }
 
-        private static void allocateHumongous() {
-            sink = new byte[700 * 1024];
+        private static void runVirtualAllocation() throws InterruptedException {
+            Thread thread = Thread.ofVirtual()
+                    .name(VIRTUAL_THREAD_NAME)
+                    .start(VirtualHumongousAllocator::allocateHumongous);
+            thread.join();
+        }
+
+        private static void runConcurrentAllocations() throws InterruptedException {
+            CountDownLatch ready = new CountDownLatch(CONCURRENT_THREAD_COUNT);
+            CountDownLatch start = new CountDownLatch(1);
+            Thread[] threads = new Thread[CONCURRENT_THREAD_COUNT];
+
+            for (int i = 0; i < CONCURRENT_THREAD_COUNT; i++) {
+                int index = i;
+                threads[i] = new Thread(() -> {
+                    ready.countDown();
+                    await(start);
+                    ConcurrentHumongousAllocator.allocateHumongous(index);
+                }, CONCURRENT_THREAD_PREFIX + i);
+                threads[i].start();
+            }
+
+            ready.await();
+            start.countDown();
+            for (Thread thread : threads) {
+                thread.join();
+            }
+        }
+
+        private static void await(CountDownLatch latch) {
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        }
+
+        private static class PlatformHumongousAllocator {
+            private static void allocateHumongous() {
+                SINKS[0] = new byte[700 * 1024];
+            }
+        }
+
+        private static class VirtualHumongousAllocator {
+            private static void allocateHumongous() {
+                SINKS[1] = new byte[700 * 1024];
+            }
+        }
+
+        private static class ConcurrentHumongousAllocator {
+            private static void allocateHumongous(int index) {
+                SINKS[2 + index] = new byte[700 * 1024];
+            }
         }
     }
 }

--- a/test/hotspot/jtreg/gc/g1/TestHumongousAllocationStackTrace.java
+++ b/test/hotspot/jtreg/gc/g1/TestHumongousAllocationStackTrace.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026, Tencent. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package gc.g1;
+
+/*
+ * @test TestHumongousAllocationStackTrace
+ * @summary Test that G1 humongous allocation debug logging prints the allocating Java thread and stack.
+ * @requires vm.gc.G1
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver gc.g1.TestHumongousAllocationStackTrace
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestHumongousAllocationStackTrace {
+    private static final String THREAD_NAME = "HumongousAllocatorThread";
+
+    public static void main(String[] args) throws Exception {
+        OutputAnalyzer output = ProcessTools.executeLimitedTestJava(
+                "-XX:+UseG1GC",
+                "-Xms32m",
+                "-Xmx32m",
+                "-XX:G1HeapRegionSize=1m",
+                "-Xlog:gc+humongous=debug",
+                HumongousAllocator.class.getName());
+
+        output.shouldHaveExitValue(0);
+        output.shouldContain("Humongous allocation succeeded");
+        output.shouldContain("thread \"" + THREAD_NAME + "\"");
+        output.shouldContain("Java stack for humongous allocation");
+        output.shouldContain("gc.g1.TestHumongousAllocationStackTrace$HumongousAllocator.allocateHumongous");
+    }
+
+    public static class HumongousAllocator {
+        private static volatile Object sink;
+
+        public static void main(String[] args) throws Exception {
+            Thread thread = new Thread(HumongousAllocator::allocateHumongous, THREAD_NAME);
+            thread.start();
+            thread.join();
+        }
+
+        private static void allocateHumongous() {
+            sink = new byte[700 * 1024];
+        }
+    }
+}


### PR DESCRIPTION
Summary:
- Added debug logging for successful G1 humongous object allocations.
- The log is enabled with `-Xlog:gc+humongous=debug`.
- The log includes the allocating Java thread name and Java stack trace.
- Added a regression test for the new logging behavior.

Testing:
- `make images` passed
- `git diff --check` passed
- Manual test with the built JDK passed
- `make test TEST=test/hotspot/jtreg/gc/g1/TestHumongousAllocationStackTrace.java` was not run because local jtreg is not configured