### PR TITLE
[RhinoBird2026] Add CompileCommand requirefullprofile support

### DIFF
--- a/.github/workflows/requirefullprofile.yml
+++ b/.github/workflows/requirefullprofile.yml
@@ -1,0 +1,141 @@
+# Copyright (c) 2026, Tencent. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+
+name: RequireFullProfile tests
+
+on:
+  push:
+    paths:
+      - .github/workflows/requirefullprofile.yml
+      - src/hotspot/share/compiler/compilationPolicy.cpp
+      - src/hotspot/share/compiler/compilationPolicy.hpp
+      - src/hotspot/share/compiler/compilerOracle.hpp
+      - test/hotspot/jtreg/compiler/oracle/TestRequireFullProfileCommand.java
+      - test/hotspot/jtreg/compiler/tiered/RequireFullProfileTest.java
+      - test/hotspot/jtreg/compiler/tiered/RequireFullProfileStopAt2Test.java
+  pull_request:
+    paths:
+      - .github/workflows/requirefullprofile.yml
+      - src/hotspot/share/compiler/compilationPolicy.cpp
+      - src/hotspot/share/compiler/compilationPolicy.hpp
+      - src/hotspot/share/compiler/compilerOracle.hpp
+      - test/hotspot/jtreg/compiler/oracle/TestRequireFullProfileCommand.java
+      - test/hotspot/jtreg/compiler/tiered/RequireFullProfileTest.java
+      - test/hotspot/jtreg/compiler/tiered/RequireFullProfileStopAt2Test.java
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: requirefullprofile-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: Linux x64 fastdebug
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Check out the JDK source
+        uses: actions/checkout@v4
+
+      - name: Build jtreg
+        uses: ./.github/actions/build-jtreg
+
+      - name: Get the Boot JDK
+        id: bootjdk
+        uses: ./.github/actions/get-bootjdk
+        with:
+          platform: linux-x64
+
+      - name: Install native build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes \
+            autoconf \
+            build-essential \
+            libasound2-dev \
+            libcups2-dev \
+            libfontconfig1-dev \
+            libfreetype6-dev \
+            libx11-dev \
+            libxext-dev \
+            libxrandr-dev \
+            libxrender-dev \
+            libxt-dev \
+            libxtst-dev \
+            unzip \
+            zip \
+            zlib1g-dev
+
+      - name: Configure fastdebug JDK
+        run: |
+          bash configure \
+            --with-conf-name=requirefullprofile \
+            --with-boot-jdk="${{ steps.bootjdk.outputs.path }}" \
+            --with-jtreg="$GITHUB_WORKSPACE/jtreg/installed" \
+            --with-debug-level=fastdebug \
+            --with-jvm-variants=server \
+            --with-zlib=system
+
+      - name: Build JDK images
+        run: make CONF_NAME=requirefullprofile images JOBS=4
+
+      - name: Verify CompileCommand parsing
+        run: |
+          make CONF_NAME=requirefullprofile test \
+            TEST="jtreg:test/hotspot/jtreg/compiler/oracle/TestRequireFullProfileCommand.java" \
+            JTREG="JOBS=1;TIMEOUT_FACTOR=4"
+
+      - name: Verify tiered compilation transitions
+        run: |
+          make CONF_NAME=requirefullprofile test \
+            TEST="jtreg:test/hotspot/jtreg/compiler/tiered/RequireFullProfileTest.java" \
+            JTREG="JOBS=1;TIMEOUT_FACTOR=4"
+
+      - name: Verify TieredStopAtLevel=2
+        run: |
+          make CONF_NAME=requirefullprofile test \
+            TEST="jtreg:test/hotspot/jtreg/compiler/tiered/RequireFullProfileStopAt2Test.java" \
+            JTREG="JOBS=1;TIMEOUT_FACTOR=4"
+
+      - name: Verify existing level 2 recompilation behavior
+        run: |
+          make CONF_NAME=requirefullprofile test \
+            TEST="jtreg:test/hotspot/jtreg/compiler/tiered/Level2RecompilationTest.java" \
+            JTREG="JOBS=1;TIMEOUT_FACTOR=4"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: requirefullprofile-test-results
+          path: |
+            build/requirefullprofile/test-results
+            build/requirefullprofile/test-support
+          if-no-files-found: warn
+          retention-days: 7

--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,6 +60,46 @@ double CompilationPolicy::_increase_threshold_at_ratio = 0;
 
 CompilationPolicy::TrainingReplayQueue CompilationPolicy::_training_replay_queue;
 
+bool CompilationPolicy::requires_full_profile(const methodHandle& method) {
+  return CompilerOracle::has_option(
+      method,
+      CompileCommandEnum::RequireFullProfile);
+}
+
+CompLevel CompilationPolicy::apply_require_full_profile(const methodHandle& method,
+                                                        CompLevel cur_level,
+                                                        CompLevel target_level) {
+  if (!CompilationModeFlag::normal() ||
+      method->is_native() ||
+      !requires_full_profile(method)) {
+    return target_level;
+  }
+
+  if (cur_level == CompLevel_full_optimization &&
+      target_level == CompLevel_full_profile) {
+    return cur_level;
+  }
+
+  if (target_level == CompLevel_limited_profile) {
+    if (cur_level >= CompLevel_full_profile) {
+      return cur_level;
+    }
+    if (highest_compile_level() >= CompLevel_full_profile) {
+      return CompLevel_full_profile;
+    }
+    // Full profiling is unavailable. Preserve the current level instead of
+    // accepting level 2 or overriding the global compilation limit.
+    return cur_level;
+  }
+
+  if (cur_level < CompLevel_full_profile &&
+      target_level == CompLevel_full_optimization) {
+    return CompLevel_full_profile;
+  }
+
+  return target_level;
+}
+
 void compilationPolicy_init() {
   CompilationPolicy::initialize();
 }
@@ -100,6 +141,8 @@ void CompilationPolicy::maybe_compile_early(const methodHandle& m, TRAPS) {
     }
     CompLevel cur_level = static_cast<CompLevel>(m->highest_comp_level());
     CompLevel next_level = trained_transition(m, cur_level, mtd, THREAD);
+    assert(next_level == apply_require_full_profile(m, cur_level, next_level),
+           "trained transition must honor requirefullprofile");
     if (next_level != cur_level && can_be_compiled(m, next_level) && !CompileBroker::compilation_is_in_queue(m)) {
       if (PrintTieredEvents) {
         print_event(FORCE_COMPILE, m(), m(), InvocationEntryBci, next_level);
@@ -806,8 +849,60 @@ CompileTask* CompilationPolicy::select_task(CompileQueue* compile_queue, JavaThr
 
   methodHandle max_method_h(THREAD, max_method);
 
-  if (max_task != nullptr && max_task->comp_level() == CompLevel_full_profile && TieredStopAtLevel > CompLevel_full_profile &&
-      max_method != nullptr && is_method_profiled(max_method_h) && !Arguments::is_compiler_only()) {
+  if (max_task != nullptr &&
+      max_task->comp_level() == CompLevel_limited_profile &&
+      max_method != nullptr) {
+    CompLevel cur_level = comp_level(max_method);
+    if (max_task->osr_bci() != InvocationEntryBci) {
+      nmethod* osr_nm = max_method->lookup_osr_nmethod_for(
+          max_task->osr_bci(), CompLevel_none, false);
+      cur_level = osr_nm == nullptr
+          ? CompLevel_none
+          : static_cast<CompLevel>(osr_nm->comp_level());
+    }
+    CompLevel adjusted_level = apply_require_full_profile(
+        max_method_h, cur_level, CompLevel_limited_profile);
+
+    if (adjusted_level == CompLevel_full_profile) {
+      max_task->set_comp_level(adjusted_level);
+
+      if (CompileBroker::compilation_is_complete(max_method_h,
+                                                 max_task->osr_bci(),
+                                                 adjusted_level)) {
+        if (PrintTieredEvents) {
+          print_event(REMOVE_FROM_QUEUE, max_method, max_method,
+                      max_task->osr_bci(), adjusted_level);
+        }
+        compile_queue->remove_and_mark_stale(max_task);
+        max_method->clear_queued_for_compilation();
+        return nullptr;
+      }
+
+      if (PrintTieredEvents) {
+        print_event(UPDATE_IN_QUEUE, max_method, max_method,
+                    max_task->osr_bci(), adjusted_level);
+      }
+    } else if (adjusted_level != CompLevel_limited_profile) {
+      if (PrintTieredEvents) {
+        print_event(REMOVE_FROM_QUEUE, max_method, max_method,
+                    max_task->osr_bci(), CompLevel_limited_profile);
+      }
+      compile_queue->remove_and_mark_stale(max_task);
+      max_method->clear_queued_for_compilation();
+      return nullptr;
+    }
+  }
+
+  if (max_task != nullptr &&
+      max_task->comp_level() == CompLevel_full_profile &&
+      TieredStopAtLevel > CompLevel_full_profile &&
+      max_method != nullptr &&
+      is_method_profiled(max_method_h) &&
+      apply_require_full_profile(max_method_h,
+                                 CompLevel_full_profile,
+                                 CompLevel_limited_profile) ==
+          CompLevel_limited_profile &&
+      !Arguments::is_compiler_only()) {
     max_task->set_comp_level(CompLevel_limited_profile);
 
     if (CompileBroker::compilation_is_complete(max_method_h, max_task->osr_bci(), CompLevel_limited_profile)) {
@@ -1225,9 +1320,9 @@ CompLevel CompilationPolicy::trained_transition_from_full_profile(const methodHa
 CompLevel CompilationPolicy::trained_transition(const methodHandle& method, CompLevel cur_level, MethodTrainingData* mtd, JavaThread* THREAD) {
   precond(MethodTrainingData::have_data());
 
-  // If there is no training data recorded for this method, bail out.
+  // Without training data, only apply the method-level state constraint.
   if (mtd == nullptr) {
-    return cur_level;
+    return apply_require_full_profile(method, cur_level, cur_level);
   }
 
   CompLevel next_level = cur_level;
@@ -1251,7 +1346,8 @@ CompLevel CompilationPolicy::trained_transition(const methodHandle& method, Comp
   if (CompilationModeFlag::high_only() && next_level < CompLevel_full_optimization) {
     return CompLevel_none;
   }
-  return (cur_level != next_level) ? limit_level(next_level) : cur_level;
+  CompLevel target_level = (cur_level != next_level) ? limit_level(next_level) : next_level;
+  return apply_require_full_profile(method, cur_level, target_level);
 }
 
 /*
@@ -1320,7 +1416,9 @@ CompLevel CompilationPolicy::common(const methodHandle& method, CompLevel cur_le
   } else {
     next_level = standard_transition<Predicate>(method, cur_level, false /*delay_profiling*/, disable_feedback);
   }
-  return (next_level != cur_level) ? limit_level(next_level) : next_level;
+
+  CompLevel target_level = (next_level != cur_level) ? limit_level(next_level) : next_level;
+  return apply_require_full_profile(method, cur_level, target_level);
 }
 
 
@@ -1553,4 +1651,3 @@ void CompilationPolicy::method_back_branch_event(const methodHandle& mh, const m
     }
   }
 }
-

--- a/src/hotspot/share/compiler/compilationPolicy.hpp
+++ b/src/hotspot/share/compiler/compilationPolicy.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -262,6 +263,11 @@ class CompilationPolicy : AllStatic {
 #endif
   // Clamp the request level according to various constraints.
   inline static CompLevel limit_level(CompLevel level);
+  // Apply requirefullprofile after global compilation-level constraints.
+  static bool requires_full_profile(const methodHandle& method);
+  static CompLevel apply_require_full_profile(const methodHandle& method,
+                                              CompLevel cur_level,
+                                              CompLevel target_level);
   // Common transition function. Given a predicate determines if a method should transition to another level.
   template<typename Predicate>
   static CompLevel common(const methodHandle& method, CompLevel cur_level, JavaThread* THREAD, bool disable_feedback = false);

--- a/src/hotspot/share/compiler/compilerOracle.hpp
+++ b/src/hotspot/share/compiler/compilerOracle.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Tencent. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,6 +56,7 @@ class methodHandle;
   option(Blackhole,  "blackhole", Bool) \
   option(CompileOnly, "compileonly", Bool)\
   option(Exclude, "exclude", Bool) \
+  option(RequireFullProfile, "requirefullprofile", Bool) \
   option(Break, "break", Bool) \
   option(BreakAtExecute, "BreakAtExecute", Bool) \
   option(BreakAtCompile, "BreakAtCompile", Bool) \

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -1,5 +1,6 @@
 ---
 # Copyright (c) 1994, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2026, Tencent. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -1785,6 +1786,15 @@ performed by the Java HotSpot VM.
 
         You can suppress this by specifying the `-XX:CompileCommand=quiet`
         option before other `-XX:CompileCommand` options.
+
+    `requirefullprofile`
+    :   In normal tiered compilation, routes tier 2 compilation and direct
+        transitions to tier 4 through tier 3 so that the specified non-native
+        method collects a full profile. Existing tier 1 decisions are
+        unchanged. If tier 3 is unavailable, a tier 2 compilation is not
+        submitted. This command doesn't override the globally available
+        compilation levels, such as the level selected by
+        `-XX:TieredStopAtLevel`.
 
 `-XX:CompileCommandFile=`*filename*
 :   Sets the file from which JIT compiler commands are read. By default, the

--- a/test/hotspot/jtreg/compiler/oracle/TestRequireFullProfileCommand.java
+++ b/test/hotspot/jtreg/compiler/oracle/TestRequireFullProfileCommand.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026, Tencent. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test parsing and lookup of CompileCommand requirefullprofile
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:.
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:CompileCommand=requirefullprofile,compiler.oracle.TestRequireFullProfileCommand::target
+ *                   compiler.oracle.TestRequireFullProfileCommand lookup
+ * @run main/othervm -Xbootclasspath/a:.
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:CompileCommand=option,compiler.oracle.TestRequireFullProfileCommand::target,requirefullprofile
+ *                   compiler.oracle.TestRequireFullProfileCommand lookup
+ * @run driver compiler.oracle.TestRequireFullProfileCommand help
+ */
+
+package compiler.oracle;
+
+import java.lang.reflect.Method;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.whitebox.WhiteBox;
+
+public class TestRequireFullProfileCommand {
+    private static final String OPTION_NAME = "requirefullprofile";
+
+    public static void main(String[] args) throws Exception {
+        if (args[0].equals("help")) {
+            checkHelp();
+        } else {
+            checkLookup();
+        }
+    }
+
+    private static void checkLookup() throws Exception {
+        WhiteBox whiteBox = WhiteBox.getWhiteBox();
+        Method target = method("target");
+        Method unmatched = method("unmatched");
+
+        Boolean value = whiteBox.getMethodBooleanOption(target, OPTION_NAME);
+        if (!Boolean.TRUE.equals(value)) {
+            throw new RuntimeException("Expected requirefullprofile=true for "
+                    + target + ", actual value: " + value);
+        }
+        if (!Boolean.TRUE.equals(whiteBox.getMethodOption(target, OPTION_NAME))) {
+            throw new RuntimeException("Universal option lookup failed for " + target);
+        }
+        if (whiteBox.getMethodBooleanOption(unmatched, OPTION_NAME) != null
+                || whiteBox.getMethodOption(unmatched, OPTION_NAME) != null) {
+            throw new RuntimeException("Unmatched method has requirefullprofile");
+        }
+    }
+
+    private static void checkHelp() throws Exception {
+        OutputAnalyzer output = ProcessTools.executeTestJava(
+                "-XX:CompileCommand=help", "-version");
+        output.shouldHaveExitValue(0)
+              .shouldContain("All available options:")
+              .shouldContain("requirefullprofile (bool)");
+    }
+
+    private static Method method(String name) throws NoSuchMethodException {
+        return TestRequireFullProfileCommand.class.getDeclaredMethod(name);
+    }
+
+    private static void target() {
+    }
+
+    private static void unmatched() {
+    }
+}

--- a/test/hotspot/jtreg/compiler/tiered/RequireFullProfileStopAt2Test.java
+++ b/test/hotspot/jtreg/compiler/tiered/RequireFullProfileStopAt2Test.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026, Tencent. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test requirefullprofile with TieredStopAtLevel=2
+ * @library /test/lib /
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ *
+ * @requires vm.flavor == "server" & vm.compiler1.enabled
+ * @requires vm.compMode != "Xcomp"
+ * @requires (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 2)
+ * @requires (vm.opt.CompilationMode == null | vm.opt.CompilationMode == "default" | vm.opt.CompilationMode == "normal")
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm/timeout=240 -Xmixed -Xbootclasspath/a:.
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:+TieredCompilation -XX:TieredStopAtLevel=2
+ *                   -XX:CompilationMode=default
+ *                   -XX:CompileThresholdScaling=0.01
+ *                   -XX:-BackgroundCompilation
+ *                   -XX:CompileCommand=dontinline,compiler.tiered.RequireFullProfileStopAt2Test::*Target
+ *                   -XX:CompileCommand=requirefullprofile,compiler.tiered.RequireFullProfileStopAt2Test::requiredTarget
+ *                   compiler.tiered.RequireFullProfileStopAt2Test
+ */
+
+package compiler.tiered;
+
+import java.lang.reflect.Method;
+
+import jdk.test.whitebox.WhiteBox;
+
+public class RequireFullProfileStopAt2Test {
+    private static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
+
+    private static final int COMP_LEVEL_NONE = 0;
+    private static final int COMP_LEVEL_LIMITED_PROFILE = 2;
+
+    private static volatile int sink;
+
+    public static void main(String[] args) throws Exception {
+        Method required = method("requiredTarget");
+        Method control = method("controlTarget");
+
+        reset(required);
+        reset(control);
+
+        for (int i = 0; i < 1_000_000; i++) {
+            sink = requiredTarget(i);
+            sink = controlTarget(i);
+            checkRequiredMethod(required);
+
+            if (WHITE_BOX.getMethodCompilationLevel(control, false)
+                    == COMP_LEVEL_LIMITED_PROFILE) {
+                checkRequiredMethod(required);
+                return;
+            }
+        }
+        throw new RuntimeException("Unmatched control method did not reach level 2");
+    }
+
+    private static void checkRequiredMethod(Method method) {
+        int regularLevel = WHITE_BOX.getMethodCompilationLevel(method, false);
+        int osrLevel = WHITE_BOX.getMethodCompilationLevel(method, true);
+        if (regularLevel != COMP_LEVEL_NONE || osrLevel != COMP_LEVEL_NONE) {
+            throw new RuntimeException(method
+                    + " must remain interpreted when Tier 3 is unavailable: "
+                    + "regular=" + regularLevel + ", OSR=" + osrLevel);
+        }
+    }
+
+    private static void reset(Method method) {
+        WHITE_BOX.deoptimizeMethod(method, false);
+        WHITE_BOX.deoptimizeMethod(method, true);
+        WHITE_BOX.clearMethodState(method);
+        WHITE_BOX.testSetDontInlineMethod(method, true);
+    }
+
+    private static Method method(String name) {
+        try {
+            return RequireFullProfileStopAt2Test.class
+                    .getDeclaredMethod(name, int.class);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static int requiredTarget(int value) {
+        return nonTrivialWork(value);
+    }
+
+    private static int controlTarget(int value) {
+        return nonTrivialWork(value);
+    }
+
+    private static int nonTrivialWork(int value) {
+        int result = value;
+        for (int i = 0; i < 4; i++) {
+            result = result * 31 + i;
+        }
+        return result;
+    }
+}

--- a/test/hotspot/jtreg/compiler/tiered/RequireFullProfileTest.java
+++ b/test/hotspot/jtreg/compiler/tiered/RequireFullProfileTest.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2026, Tencent. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test requirefullprofile tiered transitions and queue adjustments
+ * @library /test/lib /
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ *
+ * @requires vm.flavor == "server" & vm.compiler1.enabled & vm.compiler2.enabled
+ * @requires vm.compMode != "Xcomp"
+ * @requires (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4)
+ * @requires (vm.opt.CompilationMode == null | vm.opt.CompilationMode == "default" | vm.opt.CompilationMode == "normal")
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm/timeout=240 -Xmixed -Xbootclasspath/a:.
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:+TieredCompilation -XX:TieredStopAtLevel=4
+ *                   -XX:CompilationMode=default
+ *                   -XX:CompileThresholdScaling=0.01
+ *                   -XX:+BackgroundCompilation
+ *                   -XX:CompileCommand=dontinline,compiler.tiered.RequireFullProfileTest::*Target
+ *                   -XX:CompileCommand=dontinline,compiler.tiered.RequireFullProfileTest$TrivialHolder::getValue
+ *                   -XX:CompileCommand=requirefullprofile,compiler.tiered.RequireFullProfileTest::queueTarget
+ *                   -XX:CompileCommand=requirefullprofile,compiler.tiered.RequireFullProfileTest::tier2RequestTarget
+ *                   -XX:CompileCommand=requirefullprofile,compiler.tiered.RequireFullProfileTest::directTarget
+ *                   -XX:CompileCommand=requirefullprofile,compiler.tiered.RequireFullProfileTest::osrQueueTarget
+ *                   -XX:CompileCommand=requirefullprofile,compiler.tiered.RequireFullProfileTest::osrTier2RequestTarget
+ *                   -XX:CompileCommand=requirefullprofile,compiler.tiered.RequireFullProfileTest$TrivialHolder::getValue
+ *                   compiler.tiered.RequireFullProfileTest
+ */
+
+package compiler.tiered;
+
+import java.lang.reflect.Method;
+
+import jdk.test.whitebox.WhiteBox;
+
+public class RequireFullProfileTest {
+    private static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
+
+    private static final int COMP_LEVEL_NONE = 0;
+    private static final int COMP_LEVEL_SIMPLE = 1;
+    private static final int COMP_LEVEL_LIMITED_PROFILE = 2;
+    private static final int COMP_LEVEL_FULL_PROFILE = 3;
+    private static final int COMP_LEVEL_FULL_OPTIMIZATION = 4;
+    private static final int INVOCATION_ENTRY_BCI = -1;
+    private static final long COMPILATION_TIMEOUT_MS = 30_000;
+
+    private static final TrivialHolder TRIVIAL_HOLDER = new TrivialHolder();
+    private static volatile int sink;
+
+    public static void main(String[] args) throws Exception {
+        Method queue = method("queueTarget", int.class);
+        Method control = method("controlTarget", int.class);
+        Method tier2Request = method("tier2RequestTarget", int.class);
+        Method direct = method("directTarget", int.class);
+        Method osrQueue = method("osrQueueTarget", int.class);
+        Method osrTier2Request = method("osrTier2RequestTarget", int.class);
+
+        checkLevel3QueueAdjustment(queue, COMP_LEVEL_FULL_PROFILE);
+        checkLevel3QueueAdjustment(control, COMP_LEVEL_LIMITED_PROFILE);
+        checkTier2Request(tier2Request, INVOCATION_ENTRY_BCI, false);
+        checkTier2Request(osrTier2Request, 0, true);
+        checkLevel3IsNotDowngradedForOsr(osrQueue);
+        checkDirectTransitionAndTier4(direct);
+        checkTrivialMethodRemainsAtLevel1();
+    }
+
+    private static void checkLevel3QueueAdjustment(Method method,
+                                                    int expectedLevel) throws Exception {
+        reset(method, false);
+        WHITE_BOX.markMethodProfiled(method);
+        enqueue(method, COMP_LEVEL_FULL_PROFILE, INVOCATION_ENTRY_BCI);
+        waitForCompilation(method);
+        checkLevel(method, false, expectedLevel);
+    }
+
+    private static void checkTier2Request(Method method, int bci,
+                                          boolean isOsr) throws Exception {
+        reset(method, isOsr);
+        enqueue(method, COMP_LEVEL_LIMITED_PROFILE, bci);
+        waitForCompilation(method);
+        checkLevel(method, isOsr, COMP_LEVEL_FULL_PROFILE);
+    }
+
+    private static void checkLevel3IsNotDowngradedForOsr(Method method)
+            throws Exception {
+        reset(method, true);
+        WHITE_BOX.markMethodProfiled(method);
+        enqueue(method, COMP_LEVEL_FULL_PROFILE, 0);
+        waitForCompilation(method);
+        checkLevel(method, true, COMP_LEVEL_FULL_PROFILE);
+        checkNotLevel2(method);
+    }
+
+    private static void checkDirectTransitionAndTier4(Method method)
+            throws Exception {
+        reset(method, false);
+        WHITE_BOX.markMethodProfiled(method);
+
+        int firstLevel = COMP_LEVEL_NONE;
+        for (int i = 0; i < 1_000_000 && firstLevel == COMP_LEVEL_NONE; i++) {
+            sink = directTarget(i);
+            waitIfQueued(method);
+            checkNotLevel2(method);
+            firstLevel = WHITE_BOX.getMethodCompilationLevel(method, false);
+        }
+        if (firstLevel != COMP_LEVEL_FULL_PROFILE) {
+            throw new RuntimeException("Expected first regular compilation of "
+                    + method + " at level 3, actual level: " + firstLevel);
+        }
+
+        for (int i = 0; i < 1_000_000; i++) {
+            sink = directTarget(i);
+            waitIfQueued(method);
+            checkNotLevel2(method);
+            if (WHITE_BOX.getMethodCompilationLevel(method, false)
+                    == COMP_LEVEL_FULL_OPTIMIZATION) {
+                return;
+            }
+        }
+        throw new RuntimeException(method + " did not reach level 4");
+    }
+
+    private static void checkTrivialMethodRemainsAtLevel1() throws Exception {
+        Method method = TrivialHolder.class.getDeclaredMethod("getValue");
+        reset(method, false);
+
+        for (int i = 0; i < 1_000_000; i++) {
+            sink = TRIVIAL_HOLDER.getValue();
+            waitIfQueued(method);
+            int level = WHITE_BOX.getMethodCompilationLevel(method, false);
+            if (level != COMP_LEVEL_NONE) {
+                checkLevel(method, false, COMP_LEVEL_SIMPLE);
+                return;
+            }
+        }
+        throw new RuntimeException("Trivial accessor was not compiled");
+    }
+
+    private static void reset(Method method, boolean isOsr) {
+        WHITE_BOX.deoptimizeMethod(method, isOsr);
+        if (isOsr) {
+            WHITE_BOX.deoptimizeMethod(method, false);
+        }
+        WHITE_BOX.clearMethodState(method);
+        WHITE_BOX.testSetDontInlineMethod(method, true);
+    }
+
+    private static void enqueue(Method method, int level, int bci) {
+        if (!WHITE_BOX.enqueueMethodForCompilation(method, level, bci)) {
+            throw new RuntimeException("Failed to enqueue " + method
+                    + " at compilation level " + level + ", bci " + bci);
+        }
+    }
+
+    private static void waitIfQueued(Method method) throws Exception {
+        if (WHITE_BOX.isMethodQueuedForCompilation(method)) {
+            waitForCompilation(method);
+        }
+    }
+
+    private static void waitForCompilation(Method method) throws Exception {
+        long deadline = System.currentTimeMillis() + COMPILATION_TIMEOUT_MS;
+        while (WHITE_BOX.isMethodQueuedForCompilation(method)
+                && System.currentTimeMillis() < deadline) {
+            Thread.sleep(10);
+        }
+        if (WHITE_BOX.isMethodQueuedForCompilation(method)) {
+            throw new RuntimeException("Timed out waiting for compilation of " + method);
+        }
+    }
+
+    private static void checkNotLevel2(Method method) {
+        int regularLevel = WHITE_BOX.getMethodCompilationLevel(method, false);
+        int osrLevel = WHITE_BOX.getMethodCompilationLevel(method, true);
+        if (regularLevel == COMP_LEVEL_LIMITED_PROFILE
+                || osrLevel == COMP_LEVEL_LIMITED_PROFILE) {
+            throw new RuntimeException(method + " reached level 2: regular="
+                    + regularLevel + ", OSR=" + osrLevel);
+        }
+    }
+
+    private static void checkLevel(Method method, boolean isOsr, int expected) {
+        int actual = WHITE_BOX.getMethodCompilationLevel(method, isOsr);
+        if (actual != expected) {
+            throw new RuntimeException("Expected " + method
+                    + (isOsr ? " OSR" : "") + " at level " + expected
+                    + ", actual level: " + actual);
+        }
+    }
+
+    private static Method method(String name, Class<?>... parameterTypes) {
+        try {
+            return RequireFullProfileTest.class.getDeclaredMethod(name, parameterTypes);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static int queueTarget(int value) {
+        return nonTrivialWork(value);
+    }
+
+    private static int controlTarget(int value) {
+        return nonTrivialWork(value);
+    }
+
+    private static int tier2RequestTarget(int value) {
+        return nonTrivialWork(value);
+    }
+
+    private static int directTarget(int value) {
+        return nonTrivialWork(value);
+    }
+
+    private static int osrQueueTarget(int count) {
+        int result = 0;
+        for (int i = 0; i < count; i++) {
+            result += i;
+        }
+        return result;
+    }
+
+    private static int osrTier2RequestTarget(int count) {
+        int result = 0;
+        for (int i = 0; i < count; i++) {
+            result ^= i;
+        }
+        return result;
+    }
+
+    private static int nonTrivialWork(int value) {
+        int result = value;
+        for (int i = 0; i < 4; i++) {
+            result = result * 31 + i;
+        }
+        return result;
+    }
+
+    private static class TrivialHolder {
+        private int value = 42;
+
+        int getValue() {
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
Refs #5

## Summary

This change adds a new boolean CompileCommand option named `requirefullprofile`.

Methods matched by this option must collect full profiling information at Tier 3 before reaching Tier 4 and must not be compiled at Tier 2 limited-profile level.

Example usage:

```
-XX:CompileCommand=requirefullprofile,com.example.Test::target
```

The existing `option` form is also supported:

```
-XX:CompileCommand=option,com.example.Test::target,requirefullprofile
```

## Implementation

The implementation includes the following changes:

- Register `requirefullprofile` as a boolean CompileCommand option in `CompilerOracle`.
- Apply the option on a per-method basis.
- Convert Tier 2 compilation decisions for matched methods to Tier 3 when full profiling is available.
- Prevent queued Tier 3 compilation tasks from being downgraded to Tier 2.
- Cover both regular and OSR compilation tasks.
- Cover standard and training-data-assisted tiered transitions.
- Require matched methods to pass through Tier 3 before reaching Tier 4.
- Preserve Tier 1 compilation for trivial methods.
- Respect global compiler configuration and compilation-level limits.
- Document the new option in the `java` command documentation.
- Add focused jtreg tests and a GitHub Actions workflow.

## Expected behavior

When tiered compilation is enabled and Tier 4 is available, a matched method follows:

```
Tier 0 -> Tier 3 -> Tier 4
```

The method must not be compiled at Tier 2.

The option does not override global compiler configuration. For example, with:

```
-XX:TieredStopAtLevel=2
```

Tier 3 and Tier 4 are unavailable, so a matched method remains interpreted instead of being compiled at Tier 2.

Methods not matched by `requirefullprofile` retain their existing tiered compilation behavior.

## Testing

The focused `RequireFullProfile tests` GitHub Actions workflow completed successfully on Linux x64 using a fastdebug JDK build.

All four jtreg test invocations passed with exit code `0`.

### CompileCommand parsing

`compiler/oracle/TestRequireFullProfileCommand.java`

Verified:

- Direct command syntax:

  ```text
  -XX:CompileCommand=requirefullprofile,<method>
  ```

- Existing `option` command syntax:

  ```text
  -XX:CompileCommand=option,<method>,requirefullprofile
  ```

- The matched method reports `requirefullprofile=true`.
- An unmatched method does not receive the option.
- Universal CompileCommand option lookup succeeds.
- `-XX:CompileCommand=help` contains `requirefullprofile (bool)`.

Result:

```text
Passed. Execution successful
```

### Tiered compilation transitions

`compiler/tiered/RequireFullProfileTest.java`

Verified:

- A Tier 3 task for a matched method is not downgraded to Tier 2.
- An unmatched control method retains the existing Tier 3-to-Tier 2 downgrade behavior.
- An explicit Tier 2 request for a matched method is compiled at Tier 3.
- An explicit Tier 2 OSR request for a matched method is compiled at Tier 3.
- A Tier 3 OSR task for a matched method is not downgraded to Tier 2.
- A normally executed matched method first reaches Tier 3 and later reaches Tier 4.
- Neither regular nor OSR compilation reaches Tier 2 during the transition.
- A matched trivial getter remains at Tier 1 instead of being unnecessarily promoted.

Result:

```
Passed. Execution successful
```

### Global compilation-level limit

`compiler/tiered/RequireFullProfileStopAt2Test.java`

Verified with:

```
-XX:+TieredCompilation
-XX:TieredStopAtLevel=2
```

- The matched method remains interpreted because Tier 3 is unavailable.
- The unmatched control method can still reach Tier 2.
- The method-level option does not bypass the global compilation-level limit.

Result:

```
Passed. Execution successful
```

### Existing Tier 2 behavior

`compiler/tiered/Level2RecompilationTest.java`

Verified that the existing behavior remains unchanged for methods not matched by `requirefullprofile`:

- Regular compilation can still reach Tier 2.
- OSR compilation can still reach Tier 2.
- The existing Tier 3-to-Tier 2 recompilation mechanism continues to work.

The test output confirmed:

```
comp_level: 2
osr_comp_level: 2
```

Result:

```
Passed. Execution successful
```

## Compatibility

This change is method-specific and does not globally disable Tier 2 compilation.

It also does not override:

- `TieredStopAtLevel`
- disabled tiered compilation
- compiler availability
- method compilability restrictions
- non-standard compilation modes

Therefore, existing behavior is preserved for methods and configurations outside the scope of `requirefullprofile`.